### PR TITLE
added function to get all available languages at runtime

### DIFF
--- a/src/services/locale.service.ts
+++ b/src/services/locale.service.ts
@@ -166,6 +166,17 @@ import { Injectable, EventEmitter, Output } from '@angular/core';
     }
 
     /**
+     * Gets all available languages
+     * 
+     * @return An array with two-letter or three-letter codes for all available languages
+     */
+    public getAvailableLanguages(): Array<string> {
+
+        return this.languageCodes;
+
+    }
+
+    /**
      * Sets Local Storage as default.
      */
     public useLocalStorage(): void {


### PR DESCRIPTION
I noticed there was no way to see all available languages, so if you have a language selector in your webapp, you'd have to update it every time you added or removed a new locale - even the showcase has all available languages hardcoded.
As far as I see it, there's no reason not to include a getter for the languageCodes - if you want the full language name like in the showcase, you still need some mapping (or just include it in the translation), but if you're content with just the language code this should do.