### PR TITLE
do not return the "missing value" when the value is an empty string

### DIFF
--- a/src/services/translation.service.ts
+++ b/src/services/translation.service.ts
@@ -128,7 +128,7 @@ import { ServiceState } from '../models/translation/service-state';
     }
 
     private parseValue(key: string, value: string, args: any, lang: string): string {
-        if (value == null || value == "") {
+        if (value == null) {
             return this.handleMissingValue(key, args, lang);
         } else if (args) {
             return this.handleArgs(value, args);


### PR DESCRIPTION
When you have an empty string in the translations, the translate(Async) method should not return the "missing value" (the key name by default).