### PR TITLE
Fix Can't find variable: Intl for iOS/Safari

### DIFF
--- a/src/services/intl-api.ts
+++ b/src/services/intl-api.ts
@@ -4,7 +4,7 @@
 export class IntlAPI {
 
     public static hasIntl(): boolean {
-        const hasIntl: boolean = Intl && typeof Intl === "object";
+        const hasIntl: boolean = typeof Intl === "object" && Intl;
         return hasIntl;
     }
 

--- a/src/services/intl-api.ts
+++ b/src/services/intl-api.ts
@@ -4,7 +4,7 @@
 export class IntlAPI {
 
     public static hasIntl(): boolean {
-        const hasIntl: boolean = typeof Intl === "object" && Intl;
+        const hasIntl: boolean = typeof Intl === "object" && !!Intl;
         return hasIntl;
     }
 


### PR DESCRIPTION
On iOS device got thrown "Can't find variable: Intl". http://imgur.com/EZN200Z