### PR TITLE
Language detection fix for root url.

### DIFF
--- a/projects/angular-l10n/src/lib/services/l10n-location.ts
+++ b/projects/angular-l10n/src/lib/services/l10n-location.ts
@@ -63,7 +63,7 @@ import { L10N_CONFIG, L10nConfig } from '../models/l10n-config';
     public getLocalizedSegment(path: string): string | null {
         for (const element of this.config.schema) {
             const language = formatLanguage(element.locale.language, this.config.format);
-            const regex = new RegExp(`(\/${language}\/)|(\/${language}$)`);
+            const regex = new RegExp(`(\/${language}\/)|(\/${language}$)|(\/${language}?)`);
             const segments = path.match(regex);
             if (segments != null) {
                 return segments[0];


### PR DESCRIPTION
Currently query params for root url are not working using L10nRoutingModule.
Example: https://angular-ivy-anhgcn.stackblitz.io/

Opening https://angular-ivy-anhgcn.stackblitz.io/en-US/about?aaa=111 is working fine
Opening https://angular-ivy-anhgcn.stackblitz.io/en-US?aaa=111 or  https://angular-ivy-anhgcn.stackblitz.io/en-US/?aaa=111 causes error: 
`Error: Cannot match any routes. URL Segment: 'en-US'`
I've changed regexp to allow question mark.
