### PR TITLE
Language detection regexp fix.

### DIFF
--- a/projects/angular-l10n/src/lib/services/l10n-location.ts
+++ b/projects/angular-l10n/src/lib/services/l10n-location.ts
@@ -63,7 +63,7 @@ import { L10N_CONFIG, L10nConfig } from '../models/l10n-config';
     public getLocalizedSegment(path: string): string | null {
         for (const element of this.config.schema) {
             const language = formatLanguage(element.locale.language, this.config.format);
-            const regex = new RegExp(`(\/${language}\/)|(\/${language}$)|(\/${language}?)`);
+            const regex = new RegExp(`(\/${language}\/)|(\/${language}$)|(\/(${language})(?=\\?))`);
             const segments = path.match(regex);
             if (segments != null) {
                 return segments[0];


### PR DESCRIPTION
Question mark shouldn't be included into capture.

Matching examples:

<b>/en-US</b>
<b>/en-US/</b>
/en-USen-US/ not match
<b>/en-US/</b>page?aaa=111
<b>/en-US/</b>page
<b>/en-US</b>?aaa=111
/en-USx not match
<b>/en-US/</b>en-US