### PR TITLE
feat(missing-translation-handler) - add third optional param to the "…

### DIFF
--- a/projects/angular-l10n/src/lib/services/l10n-missing-translation-handler.ts
+++ b/projects/angular-l10n/src/lib/services/l10n-missing-translation-handler.ts
@@ -9,15 +9,16 @@ import { Injectable } from '@angular/core';
      * This method must contain the logic to handle missing values.
      * @param key The key that has been requested
      * @param value Null or empty string
+     * @param params Optional parameters contained in the key
      * @return The value
      */
-    public abstract handle(key: string, value?: string): string | any;
+    public abstract handle(key: string, value?: string, params?: any): string | any;
 
 }
 
 @Injectable() export class L10nDefaultMissingTranslationHandler implements L10nMissingTranslationHandler {
 
-    public handle(key: string, value?: string): string | any {
+    public handle(key: string, value?: string, params?: any): string | any {
         return key;
     }
 

--- a/projects/angular-l10n/src/lib/services/l10n-translation.service.ts
+++ b/projects/angular-l10n/src/lib/services/l10n-translation.service.ts
@@ -90,7 +90,7 @@ import { L10nLocation } from './l10n-location';
 
         const value = getValue(keys, this.data[language], this.config.keySeparator);
 
-        return value ? this.translationHandler.parseValue(keys, params, value) : this.missingTranslationHandler.handle(keys, value);
+        return value ? this.translationHandler.parseValue(keys, params, value) : this.missingTranslationHandler.handle(keys, value, params);
     }
 
     /**


### PR DESCRIPTION
…handle" method to accept option parameters contained in the translation key.

This will allow us to handle optional params in the missing translations if we want to fallback to a default language (the language we are sure all translations are up to date), something like this:

```
@Injectable()
export class MissingTranslation implements L10nMissingTranslationHandler {
    private translation: L10nTranslationService;

    constructor(@Optional() private injector: Injector) {}

    public handle(key: string, value?: string, params?: any): string | any {
        // avoid cyclic dependency
        this.translation = this.injector.get(L10nTranslationService);
        return this.translation.translate(key, params, 'en-US');
    }
}
```