### PR TITLE
refactor: improve signature of l10n-translate-pipe for better type inference

### DIFF
--- a/projects/angular-l10n/src/lib/pipes/l10n-translate.pipe.ts
+++ b/projects/angular-l10n/src/lib/pipes/l10n-translate.pipe.ts
@@ -12,6 +12,9 @@ export class L10nTranslatePipe implements PipeTransform {
 
     constructor(protected translation: L10nTranslationService) { }
 
+    public transform(key: null, language: string, params?: any): null;
+    public transform(key: "", language: string, params?: any): null;
+    public transform(key: string, language: string, params?: any): string;
     public transform(key: any, language: string, params?: any): string | null {
         if (key == null || key === '') return null;
 


### PR DESCRIPTION
In applications using "strictTemplates" angular compiler option, the signature of the translate pipe is problematic: Regardless of the passed key, the return type always includes `null`. In reality however, unless `null` or an empty string is passed, the pipe actually always returns a string.

Example: 
![Screenshot 2025-04-14 at 12 28 16](https://github.com/user-attachments/assets/c3aaeabd-4627-4191-9bb0-ce1336919ae8)

This adds some overload signatures to align with the pipes actual behaviour.