### PR TITLE
fix: add fallback overload signature for l10n-translate pipe

### DIFF
--- a/projects/angular-l10n/src/lib/pipes/l10n-translate.pipe.ts
+++ b/projects/angular-l10n/src/lib/pipes/l10n-translate.pipe.ts
@@ -15,6 +15,7 @@ export class L10nTranslatePipe implements PipeTransform {
     public transform(key: null, language: string, params?: any): null;
     public transform(key: "", language: string, params?: any): null;
     public transform(key: string, language: string, params?: any): string;
+    public transform(key: any, language: string, params?: any): string | null;
     public transform(key: any, language: string, params?: any): string | null {
         if (key == null || key === '') return null;
 
@@ -33,6 +34,7 @@ export class L10nTranslateAsyncPipe extends L10nAsyncPipe implements PipeTransfo
     public transform(key: null, params?: any, language?: string): null;
     public transform(key: "", params?: any, language?: string): null;
     public transform(key: string, params?: any, language?: string): string;
+    public transform(key: any, params?: any, language?: string): string | null;
     public transform(key: any, params?: any, language?: string): string | null {
         if (key == null || key === '') return null;
 


### PR DESCRIPTION
Fixes a regression from my previous change (#351) where I missed the fallback overload that matches the function signature. This introduced new type errors when upgrading to v17.

![Screenshot 2025-06-16 at 08 15 20](https://github.com/user-attachments/assets/74a58eab-fdc1-401f-8c67-b9f7560ff7df)
