### PR TITLE
refactor: add forRoot method to L10nIntlModule

### DIFF
--- a/projects/angular-l10n/src/lib/modules/l10n-intl.module.ts
+++ b/projects/angular-l10n/src/lib/modules/l10n-intl.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { L10nDatePipe, L10nDateAsyncPipe } from '../pipes/l10n-date.pipe';
 import { L10nNumberPipe, L10nNumberAsyncPipe } from '../pipes/l10n-number.pipe';
@@ -47,6 +47,14 @@ import { L10nIntlService } from '../services/l10n-intl.service';
         L10nPluralDirective,
         L10nDisplayNamesDirective
     ],
-    providers: [L10nIntlService]
 })
-export class L10nIntlModule { }
+export class L10nIntlModule { 
+
+    public static forRoot(): ModuleWithProviders<L10nIntlModule> {
+        return {
+            ngModule: L10nIntlModule,
+            providers: [L10nIntlService]
+        };
+    }
+
+}

--- a/projects/angular-l10n/src/tests/l10n-date.directive.spec.ts
+++ b/projects/angular-l10n/src/tests/l10n-date.directive.spec.ts
@@ -46,7 +46,7 @@ describe('L10nDateDirective', () => {
             declarations: [MockComponent],
             imports: [
                 L10nTranslationModule.forRoot(config),
-                L10nIntlModule
+                L10nIntlModule.forRoot()
             ]
         }).createComponent(MockComponent);
         comp = fixture.componentInstance;

--- a/projects/angular-l10n/src/tests/l10n-intl.service.spec.ts
+++ b/projects/angular-l10n/src/tests/l10n-intl.service.spec.ts
@@ -33,7 +33,7 @@ describe('L10nIntlService', () => {
         TestBed.configureTestingModule({
             imports: [
                 L10nTranslationModule.forRoot(config),
-                L10nIntlModule
+                L10nIntlModule.forRoot()
             ]
         });
         loader = TestBed.inject(L10nLoader);


### PR DESCRIPTION
BREAKING CHANGE:
L10nIntlModule doesn't ship with a provider for L10nIntlService anymore. Use L10nIntlModule.forRoot() or provideL10nIntl() instead to include a provider for L10nIntlService.